### PR TITLE
disable goerr113

### DIFF
--- a/golangci-lint/.golangci.yml
+++ b/golangci-lint/.golangci.yml
@@ -58,7 +58,6 @@ linters:
     - gocritic
     - gocyclo
     - gocognit
-    - goerr113    #only add if go > 1.13
     - errorlint   #only add if go > 1.13
     - gofmt
     - goimports
@@ -93,6 +92,7 @@ linters:
   # - goconst   #looks for repetitions of variables that should go on constant
   # - godot
   # - godox
+  # - goerr113    # We do not have clearly defined error types yet.
   # - interfacer
   # - lll
   # - nakedret


### PR DESCRIPTION
No integration is defining errors, and this linter make the pr fail.
Refactoring all errors of integrations is quite time consuming and just defining new ones is not consistent with the existing code.