### PR TITLE
remove deprecated nolintlint option

### DIFF
--- a/golangci-lint/.golangci.yml
+++ b/golangci-lint/.golangci.yml
@@ -40,7 +40,6 @@ linters-settings:
   misspell:
     locale: US
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
     allow-unused: false # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: true # require nolint directives to be specific about which linter is being skipped


### PR DESCRIPTION
This will have not effects other than avoid confusion when you see the pipeline failing because of this not being honor. 

this was deprecated in [1.48](https://github.com/golangci/golangci-lint/releases/tag/v1.48.0)
https://github.com/golangci/golangci-lint/pull/3002