### PR TITLE
fix(depguard): we should disable it since it is not used anymore

### DIFF
--- a/golangci-lint-limited/.golangci.yml
+++ b/golangci-lint-limited/.golangci.yml
@@ -47,7 +47,6 @@ linters:
   enable:
     - bodyclose
     - deadcode
-    - depguard
     - dogsled
     - dupl
     - errcheck
@@ -58,8 +57,8 @@ linters:
     - gocritic
     - gocyclo
     - gocognit
-    - goerr113    #only add if go > 1.13
-    - errorlint   #only add if go > 1.13
+    - goerr113
+    - errorlint
     - gofmt
     - goimports
     - golint
@@ -89,6 +88,7 @@ linters:
   # don't enable:
   # - asciicheck
   # - scopelint
+  # - depguard
   # - gochecknoglobals
   # - goconst   #looks for repetitions of variables that should go on constant
   # - godot


### PR DESCRIPTION
Disabled due to https://github.com/golangci/golangci-lint/issues/3877


Depguard now expects a list of allow/deny list.

> Then it's because you are using depguard without any configuration.
   You have to either add a configuration or disable depguard.
    The default rule of depguard is to allow only std lib in all files.