### PR TITLE
chore: remove/upgrade deprecated linters

### DIFF
--- a/golangci-lint-limited/.golangci.yml
+++ b/golangci-lint-limited/.golangci.yml
@@ -7,20 +7,15 @@ linters-settings:
   funlen:
     lines: 100
     statements: 50
-  gci:
-    local-prefixes: github.com/golangci/golangci-lint
   #  goconst:
   #    min-len: 2
   #    min-occurrences: 2
   gocyclo:
     min-complexity: 10
-  gomnd:
-    settings:
-      mnd:
-        #  don't include the "operation" and "assign"
-        checks: [argument, case, condition, return]
+  mnd:
+    #  don't include the "operation" and "assign"
+    checks: [argument, case, condition, return]
   govet:
-    check-shadowing: true
     settings:
       printf:
         funcs:
@@ -41,7 +36,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - dogsled
     - dupl
     - errcheck
@@ -52,11 +46,11 @@ linters:
     - gocritic
     - gocyclo
     - gocognit
-    - goerr113
+    - err113
     - errorlint
     - gofmt
     - goimports
-    - gomnd
+    - mnd
     - goprintffuncname
     - gosec
     - gosimple

--- a/golangci-lint/.golangci.yml
+++ b/golangci-lint/.golangci.yml
@@ -14,17 +14,12 @@ linters-settings:
   funlen:
     lines: 100
     statements: 50
-  gci:
-    local-prefixes: github.com/golangci/golangci-lint
   gocyclo:
     min-complexity: 10
-  gomnd:
-    settings:
-      mnd:
-        # don't include the "operation" and "assign"
-        checks: [argument, case, condition, return]
+  mnd:
+    # don't include the "operation" and "assign"
+    checks: [argument, case, condition, return]
   govet:
-    check-shadowing: true
     settings:
       printf:
         funcs:
@@ -58,7 +53,6 @@ linters:
     - containedctx
     - contextcheck
     - cyclop
-    - deadcode
     # We currently don't want to keep a list of allowed dependencies.
     # - depguard  
     - dogsled
@@ -67,7 +61,6 @@ linters:
     - errcheck
     - errname
     - errorlint
-    - execinquery
     - exhaustive
     # Initializing structs with all fields is nonsense.
     # - exhaustruct
@@ -86,12 +79,12 @@ linters:
     - godot
     # TODOs are fine.
     #- godox
-    - goerr113
+    - err113
     - gofmt
     - gofumpt
     - goheader
     - goimports
-    - gomnd
+    - mnd
     # We need replacement to "fix" vulnerability issues.
     # - gomoddirectives
     - gomodguard


### PR DESCRIPTION
It removes/upgrades deprecated linters in order to fix warnings/errors in pipelines. Example: [nri-kafka](https://github.com/newrelic/nri-kafka/actions/runs/8933006384/job/24621873807?pr=294)

```
Running [/home/runner/golangci-lint-1.58.0-linux-amd64/golangci-lint run --out-format=github-actions --new-from-patch=/tmp/tmp-4774-134jry3C6xNz/pull.patch --new=false --new-from-rev=] in [] ...
  level=warning msg="[config_reader] The configuration option `linters.govet.check-shadowing` is deprecated. Please enable `shadow` instead, if you are not using `enable-all`."
  level=warning msg="[config_reader] The configuration option `linters.gci.local-prefixes` is deprecated, please use `prefix()` inside `linters.gci.sections`."
  level=warning msg="[config_reader] The configuration option `linters.gomnd.settings` is deprecated. Please use the options `linters.gomnd.checks`,`linters.gomnd.ignored-numbers`,`linters.gomnd.ignored-files`,`linters.gomnd.ignored-functions`."
  level=warning msg="[lintersdb] The name \"goerr113\" is deprecated. The linter has been renamed to: err113."
  level=warning msg="The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused."
  level=warning msg="The linter 'gomnd' is deprecated (since v1.58.0) due to: The linter has been renamed. Replaced by mnd."
  level=error msg="[linters_context] deadcode: This linter is fully inactivated: it will not produce any reports."
  level=warning msg="[runner] Can't run linter goanalysis_metalinter: failed to pre-run gomnd: failed to configure analyzers: settings key \"mnd\" must be valid analyzer name, valid analyzers: [gomnd]"
  level=error msg="Running error: can't run linter goanalysis_metalinter\nfailed to pre-run gomnd: failed to configure analyzers: settings key \"mnd\" must be valid analyzer name, valid analyzers: [gomnd]"
  
  Error: golangci-lint exit with code 3
  Ran golangci-lint in [23](https://github.com/newrelic/nri-kafka/actions/runs/8933006384/job/24621873807?pr=294#step:6:25)09ms
```