### PR TITLE
fix: remove exportloopref

### DIFF
--- a/golangci-lint-limited/.golangci.yml
+++ b/golangci-lint-limited/.golangci.yml
@@ -39,7 +39,6 @@ linters:
     - dogsled
     - dupl
     - errcheck
-    - exportloopref
     - exhaustive
     - funlen
     - gochecknoinits

--- a/golangci-lint/.golangci.yml
+++ b/golangci-lint/.golangci.yml
@@ -64,7 +64,6 @@ linters:
     - exhaustive
     # Initializing structs with all fields is nonsense.
     # - exhaustruct
-    - exportloopref
     - forbidigo
     - forcetypeassert
     - funlen


### PR DESCRIPTION
I was getting this error in my gha

`level=error msg="[linters_context] exportloopref: This linter is fully inactivated: it will not produce any reports."`

https://github.com/kyoh86/exportloopref

Please go ahead and merge after review. 