### PR TITLE
update linter config

### DIFF
--- a/golangci-lint/.golangci.yml
+++ b/golangci-lint/.golangci.yml
@@ -52,6 +52,8 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
+    # succeeds exportloopref
+    - copyloopvar
     - cyclop
     # We currently don't want to keep a list of allowed dependencies.
     # - depguard  
@@ -115,13 +117,16 @@ linters:
     - stylecheck
     # Tags formats vary depending on the project so tagliatelle des not help in common configuration.
     #- tagliatelle
-    - tenv
+    # deprecated as of v1.64, succeeded by usetesting
+    #- tenv
     # _test packages help to test the APIs but internal tests can also be useful, so we do not enforce the black-box approach for all tests.
     # - testpackage
     - thelper
     - tparallel
     - unconvert
     - unparam
+    # succeeds tenv
+    - usetesting
     # Varnamelen is pretty annoying for tests and short methods. Short vars are bad but we trust developer's criteria.
     #- varnamelen
     - wastedassign


### PR DESCRIPTION
add copyloopvar, which succeeded exportloopvar

replace tenv with usetesting, which was succeeded by it

errors in workflow

```
  level=warning msg="The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar."
  level=warning msg="The linter 'tenv' is deprecated (since v1.64.0) due to: Duplicate feature another linter. Replaced by usetesting."
  level=error msg="[linters_context] exportloopref: This linter is fully inactivated: it will not produce any reports."
```